### PR TITLE
Separating the primary URL into a section

### DIFF
--- a/draft-ietf-wpack-bundled-responses.md
+++ b/draft-ietf-wpack-bundled-responses.md
@@ -44,9 +44,8 @@ normative:
 
 Web bundles provide a way to bundle up groups of HTTP responses, with the
 request URLs and content negotiation that produced them, to transmit or store
-together. They can include multiple top-level resources with one identified as
-the default by a primaryUrl metadata, provide random access to their component
-exchanges, and efficiently store 8-bit resources.
+together. They can include multiple top-level resources, provide random access
+to their component exchanges, and efficiently store 8-bit resources.
 
 --- middle
 
@@ -136,7 +135,6 @@ schema:
 webbundle = [
   magic: h'F0 9F 8C 90 F0 9F 93 A6',
   version: bytes .size 4,
-  primary-url: whatwg-url,
   section-lengths: bytes .cbor section-lengths,
   sections: [* any ],
   length: bytes .size 8,  ; Big-endian number of bytes in the bundle.
@@ -167,13 +165,7 @@ elements (up to 15).
 
 The `version` bytestring MUST be `31 00 00 00` in base 16 (an ASCII "1" followed
 by 3 0s) for this version of bundles. If the recipient doesn't support the
-version in this field, it MUST either ignore the bundle or fetch and use the
-content of the `primary-url` field instead.
-
-The `primary-url` field identifies both a fallback when the recipient doesn't
-understand the bundle and a default resource inside the bundle to use when the
-recipient doesn't have more specific instructions. This field MAY be an empty
-string, although protocols using bundles MAY themselves forbid that empty value.
+version in this field, it MUST ignore the bundle.
 
 The `section-lengths` and `sections` arrays contain the actual content of the
 bundle and are defined in {{sections}}. The `section-lengths` array is embedded
@@ -227,6 +219,7 @@ jump directly to the section it needs. This specification defines the following
 sections:
 
 * `"index"` ({{index-section}})
+* `"primary"` ({{primary-section}})
 * `"manifest"` ({{manifest-section}})
 * `"critical"` ({{critical-section}})
 * `"responses"` ({{responses-section}})
@@ -299,6 +292,15 @@ entire index MUST fail to parse.
 
 A combination of available-values that is omitted from the bundle MUST be
 signaled by setting its offset and length to 0.
+
+### The primary section {#primary-section}
+
+~~~ cddl
+primary = whatwg-url
+~~~
+
+The "primary" section records a single URL identifying the primary URL of the
+bundle. The URL MUST refer to a resource with representations contained in the bundle itself.
 
 ### The manifest section {#manifest-section}
 


### PR DESCRIPTION
Closes WICG/webpackage#616.

This is transferred from @littledan's WICG/webpackage#617.