### PR TITLE
Add the primary-url section to the initial IANA registration.

### DIFF
--- a/draft-ietf-wpack-bundled-responses.md
+++ b/draft-ietf-wpack-bundled-responses.md
@@ -513,6 +513,7 @@ Initial Assignments:
 
 | Section Name | Specification |
 | "index" | {{index-section}} |
+| "primary" | {{primary-section}} |
 | "manifest" | {{manifest-section}} |
 | "critical" | {{critical-section}} |
 | "responses" | {{responses-section}} |


### PR DESCRIPTION
We forgot this in #3.

Preview at https://wpack-wg.github.io/bundled-responses/add-primary-section-iana/draft-ietf-wpack-bundled-responses.html#name-web-bundle-section-name-reg