### PR TITLE
Remove the manifest section

### DIFF
--- a/draft-ietf-wpack-bundled-responses.md
+++ b/draft-ietf-wpack-bundled-responses.md
@@ -559,7 +559,7 @@ The `index` section maps URLs ({{URL}}) to offset/length pairs in the [`response
 
 | name    | type                                          | size     | description                    |
 | ------- ----------------------------------------------- | -------- | ------------------------------ |
-| `index` | map ([`whatwg-url`](#type-whatg-url) => [`location-in-responses`](#type-location-in-responses)) | variable | A map from a URL to a location |
+| `index` | map (`whatwg-url` => [`location-in-responses`](#type-location-in-responses)) | variable | A map from a URL to a location |
 
 #### Type: `whatwg-url`
 

--- a/draft-ietf-wpack-bundled-responses.md
+++ b/draft-ietf-wpack-bundled-responses.md
@@ -18,7 +18,6 @@ author:
     email: jyasskin@chromium.org
 
 normative:
-  appmanifest: W3C.WD-appmanifest-20180523
   CBORbis: RFC8949
   CDDL: RFC8610
   FETCH:
@@ -220,7 +219,6 @@ sections:
 
 * `"index"` ({{index-section}})
 * `"primary"` ({{primary-section}})
-* `"manifest"` ({{manifest-section}})
 * `"critical"` ({{critical-section}})
 * `"responses"` ({{responses-section}})
 
@@ -301,26 +299,6 @@ primary = whatwg-url
 
 The "primary" section records a single URL identifying the primary URL of the
 bundle. The URL MUST refer to a resource with representations contained in the bundle itself.
-
-### The manifest section {#manifest-section}
-
-~~~ cddl
-manifest = whatwg-url
-~~~
-
-The "manifest" section records a single URL identifying the manifest of the
-bundle. The URL MUST refer to a resource with representations contained in the bundle itself.
-
-The bundle can contain multiple representations at this URL, and the client is
-expected to content-negotiate for the best one. For example, a client might
-select the one matching an `accept` header of `application/manifest+json`
-({{appmanifest}}) and an `accept-language` header of `es-419`.
-
-Many bundles have a choice between identifying their manifest in this section or
-in their primary resource, especially if that resource is an HTML file.
-Identifying the manifest in this section can help recipients apply fields in the
-manifest sooner, for example to show a splash screen before parsing the primary
-resource.
 
 ### The critical section {#critical-section}
 
@@ -417,8 +395,8 @@ following strategies:
    submitting content or existing signatures reaching a certain age, rather than
    in response to untrusted-reader queries.
 1. Do all of:
-   1. If the bundle's contained URLs (e.g. in the manifest and index) are
-      derived from the request for the bundle,
+   1. If the bundle's contained URLs (e.g. in the index) are derived from the
+      request for the bundle,
       [percent-encode](https://url.spec.whatwg.org/#percent-encode) ({{URL}})
       any bytes that are greater than 0x7E or are not [URL code
       points](https://url.spec.whatwg.org/#url-code-points) ({{URL}}) in these
@@ -514,7 +492,6 @@ Initial Assignments:
 | Section Name | Specification |
 | "index" | {{index-section}} |
 | "primary" | {{primary-section}} |
-| "manifest" | {{manifest-section}} |
 | "critical" | {{critical-section}} |
 | "responses" | {{responses-section}} |
 

--- a/draft-ietf-wpack-bundled-responses.md
+++ b/draft-ietf-wpack-bundled-responses.md
@@ -559,7 +559,7 @@ The `index` section maps URLs ({{URL}}) to offset/length pairs in the [`response
 
 | name    | type                                          | size     | description                    |
 | ------- ----------------------------------------------- | -------- | ------------------------------ |
-| `index` | map (`whatwg-url` => [`location-in-responses`](#type-location-in-responses)) | variable | A map from a URL to a location |
+| `index` | map ([`whatwg-url`](#type-whatwg-url) => [`location-in-responses`](#type-location-in-responses)) | variable | A map from a URL to a location |
 
 #### Type: `whatwg-url`
 


### PR DESCRIPTION
This PR removes the manifest section.

The motivation is to factor the "core" Web Bundles specification to include just the minimal amount needed to support cases like subresource loading, which does not need a manifest. This and other removed sections can be defined in other documents in the future.

Adapted from https://github.com/WICG/webpackage/pull/619