### PR TITLE
Editorial: Move whatwg-url definition to index section

### DIFF
--- a/draft-ietf-wpack-bundled-responses.md
+++ b/draft-ietf-wpack-bundled-responses.md
@@ -135,8 +135,6 @@ webbundle = [
   sections: [* any ],
   length: bytes .size 8,  ; Big-endian number of bytes in the bundle.
 ]
-
-whatwg-url = tstr
 ~~~~~
 
 When serialized, the bundle MUST satisfy the core deterministic encoding
@@ -236,6 +234,7 @@ sections are optional.
 
 ~~~ cddl
 index = {* whatwg-url => [ location-in-responses ] }
+whatwg-url = tstr
 location-in-responses = (offset: uint, length: uint)
 ~~~
 


### PR DESCRIPTION
https://github.com/wpack-wg/bundled-responses/commit/af91e1701ac9eb0c27d12fa4cd30c8ebcf1ddb50 have removed `primary-url: whatwg-url` from the top-level structure. So we don't need to have the definition of `whatwg-url` in the top-level structure. We should have it in the index section.